### PR TITLE
fix(nvim-tree): show git dotfiles

### DIFF
--- a/nvim/lua/plugins/init.lua
+++ b/nvim/lua/plugins/init.lua
@@ -355,7 +355,6 @@ return {
         on_attach = on_attach,
       filters = {
         dotfiles = false,
-        custom = { ".DS_Store", ".git" },
       },
       disable_netrw = true,
       hijack_netrw = true,


### PR DESCRIPTION
## Summary
- remove the nvim-tree custom filter that matched .git paths too broadly
- keep dotfiles visible with dotfiles = false so .github and .gitignore can show when present

## Testing
- nvim --headless '+lua require("lazy").load({ plugins = { "nvim-tree.lua" } })' '+qa'