### PR TITLE
feat(go): configure Neovim tooling

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -53,6 +53,14 @@ source $ZSH/oh-my-zsh.sh
 # Mason (Neovim LSP/tools) bin directory
 export PATH="$HOME/.local/share/nvim/mason/bin:$PATH"
 
+# Go toolchain installed by the official macOS installer
+export PATH="/usr/local/go/bin:$PATH"
+
+# Go tools installed by `go install` (gopls, goimports, dlv, etc.)
+if command -v go >/dev/null 2>&1; then
+  export PATH="$(go env GOPATH)/bin:$PATH"
+fi
+
 # DISABLED: No longer needed — fs_event watcher in autocmds.lua replaced hook-based approach
 # Start Neovim with server socket for Claude Code integration
 # Socket named by directory; multiple instances get numbered suffix

--- a/nvim/lua/configs/conform.lua
+++ b/nvim/lua/configs/conform.lua
@@ -2,6 +2,7 @@ return {
   formatters_by_ft = {
     lua = { "stylua" },
     python = { "ruff_fix", "ruff_format" },
+    go = { "goimports", "gofmt" },
   },
   format_on_save = {
     timeout_ms = 3000,

--- a/nvim/lua/configs/lspconfig.lua
+++ b/nvim/lua/configs/lspconfig.lua
@@ -199,6 +199,27 @@ M.capabilities.textDocument.completion.completionItem = {
     -- Apply our capabilities and on_init to ALL LSP servers
     -- "*" is a wildcard that matches any server name
     vim.lsp.config("*", { capabilities = M.capabilities, on_init = M.on_init })
+
+    -- Compatibility helper: newer Neovim/native LSP setups may not provide :LspInfo.
+    -- This gives us a quick way to see which LSP clients are attached to the current buffer.
+    if vim.fn.exists(":LspInfo") == 0 then
+      vim.api.nvim_create_user_command("LspInfo", function()
+        local clients = vim.lsp.get_clients { bufnr = 0 }
+
+        if #clients == 0 then
+          vim.notify("No LSP clients attached to the current buffer", vim.log.levels.WARN, { title = "LspInfo" })
+          return
+        end
+
+        local lines = { "LSP clients attached to current buffer:" }
+        for _, client in ipairs(clients) do
+          local root_dir = client.config and client.config.root_dir or "unknown root"
+          table.insert(lines, string.format("- %s (id=%s, root=%s)", client.name, client.id, root_dir))
+        end
+
+        vim.notify(table.concat(lines, "\n"), vim.log.levels.INFO, { title = "LspInfo" })
+      end, { desc = "Show LSP clients attached to the current buffer" })
+    end
     
     -- Apply Lua-specific settings to the lua_ls (lua-language-server)
     vim.lsp.config("lua_ls", { settings = lua_lsp_settings })
@@ -226,20 +247,44 @@ M.capabilities.textDocument.completion.completionItem = {
       },
     })
 
+    -- Gopls: official Go language server
+    vim.lsp.config("gopls", {
+      settings = {
+        gopls = {
+          completeUnimported = true,
+          staticcheck = true,
+          usePlaceholders = true,
+          analyses = {
+            nilness = true,
+            unusedparams = true,
+            unusedwrite = true,
+            useany = true,
+          },
+        },
+      },
+    })
+
     -- Enable the Lua language server
     -- This tells Neovim to start lua_ls when editing Lua files
     vim.lsp.enable "lua_ls"
 
     -- Enable language servers
     -- These provide completions and diagnostics for their respective file types
-    local servers = { "html", "cssls", "pyright", "ruff", "ts_ls", "dockerls", "docker_compose_language_service" }
+    local servers = {
+      "html",
+      "cssls",
+      "pyright",
+      "ruff",
+      "ts_ls",
+      "dockerls",
+      "docker_compose_language_service",
+      "gopls",
+    }
     vim.lsp.enable(servers)
   end
   
   -- Export the module so other files can require() it
   return M
-
-
 
 
 

--- a/nvim/lua/options.lua
+++ b/nvim/lua/options.lua
@@ -192,7 +192,34 @@ opt.shortmess:append("sI")
 opt.whichwrap:append("<>[]hl")
 
 -- ============================================================================
--- SECTION 9: DISABLE UNUSED PROVIDERS
+-- SECTION 9: EXTERNAL TOOL PATHS
+-- ============================================================================
+-- Make tools installed outside the shell startup path visible to Neovim.
+-- Mason is lazy-loaded, so its bin directory must be available before LSP starts.
+
+local function prepend_path(path)
+  path = vim.fn.expand(path)
+
+  if path == "" or vim.fn.isdirectory(path) == 0 then
+    return
+  end
+
+  local separator = package.config:sub(1, 1) == "\\" and ";" or ":"
+  for entry in string.gmatch(vim.env.PATH or "", "([^" .. separator .. "]+)") do
+    if entry == path then
+      return
+    end
+  end
+
+  vim.env.PATH = path .. separator .. (vim.env.PATH or "")
+end
+
+prepend_path "$HOME/.local/share/nvim/mason/bin"
+prepend_path "/usr/local/go/bin"
+prepend_path "$HOME/go/bin"
+
+-- ============================================================================
+-- SECTION 10: DISABLE UNUSED PROVIDERS
 -- ============================================================================
 -- Neovim can use external interpreters for plugins (Python, Ruby, etc.)
 -- Most modern plugins are pure Lua, so we disable unused providers


### PR DESCRIPTION
## Summary
- add Go paths to shell/Neovim environment
- configure gopls and Go formatting
- preserve existing Telescope LSP references mapping from main

## Validation
- git diff --cached --check
- nvim --headless '+lua require("lazy").load({ plugins = { "nvim-lspconfig", "conform.nvim" } })' '+qa'