### PR TITLE
feat(treesitter): migrate to main branch API

### DIFF
--- a/nvim/lazy-lock.json
+++ b/nvim/lazy-lock.json
@@ -24,7 +24,7 @@
   "nvim-lint": { "branch": "master", "commit": "bcd1a44edbea8cd473af7e7582d3f7ffc60d8e81" },
   "nvim-lspconfig": { "branch": "master", "commit": "92ee7d42320edfbb81f3cad851314ab197fa324a" },
   "nvim-tree.lua": { "branch": "master", "commit": "037d89e60fb01a6c11a48a19540253b8c72a3c32" },
-  "nvim-treesitter": { "branch": "master", "commit": "42fc28ba918343ebfd5565147a42a26580579482" },
+  "nvim-treesitter": { "branch": "main", "commit": "4916d6592ede8c07973490d9322f187e07dfefac" },
   "nvim-web-devicons": { "branch": "master", "commit": "803353450c374192393f5387b6a0176d0972b848" },
   "plenary.nvim": { "branch": "master", "commit": "b9fd5226c2f76c951fc8ed5923d85e4de065e509" },
   "render-markdown.nvim": { "branch": "main", "commit": "c54380dd4d8d1738b9691a7c349ecad7967ac12e" },

--- a/nvim/lua/configs/treesitter.lua
+++ b/nvim/lua/configs/treesitter.lua
@@ -1,84 +1,54 @@
 -- Treesitter Configuration
--- nvim-treesitter provides advanced syntax highlighting and code understanding
--- Unlike traditional regex-based highlighting, treesitter actually PARSES code
--- This gives accurate highlighting that understands language structure
+-- nvim-treesitter installs parsers and queries; Neovim starts the parsers.
 
--- Load base46's syntax and treesitter themes
--- pcall() = protected call, won't error if files don't exist
--- This provides graceful degradation if themes aren't cached yet
 pcall(function()
-  -- Load syntax highlight colors (general code colors)
   dofile(vim.g.base46_cache .. "syntax")
-  -- Load treesitter-specific highlight colors
   dofile(vim.g.base46_cache .. "treesitter")
 end)
 
--- Return the configuration table
+local parsers = {
+  "lua",
+  "luadoc",
+  "printf",
+  "vim",
+  "vimdoc",
+  "python",
+  "go",
+  "gomod",
+  "gosum",
+  "gowork",
+  "typescript",
+  "tsx",
+  "javascript",
+  "markdown",
+  "markdown_inline",
+}
+
+local filetypes = {
+  "lua",
+  "vim",
+  "vimdoc",
+  "python",
+  "go",
+  "gomod",
+  "gosum",
+  "gowork",
+  "typescript",
+  "typescriptreact",
+  "javascript",
+  "javascriptreact",
+  "markdown",
+}
+
 return {
-  -- PARSER INSTALLATION
-  -- Treesitter needs language-specific parsers to understand each language
-  
-  -- List of parsers to install automatically
-  -- These are the minimum parsers needed for basic Neovim config editing
-  ensure_installed = {
-    "lua",        -- Lua language (for Neovim config)
-    "luadoc",     -- Lua documentation comments
-    "printf",     -- Printf-style format strings (used in many languages)
-    "vim",        -- Vimscript language
-    "vimdoc",     -- Vim documentation (help files)
-    "python",     -- Python language
-    "typescript", -- TypeScript language
-    "tsx",        -- TypeScript with JSX (React)
-    "javascript", -- JavaScript (needed for TypeScript projects)
+  setup = {
+    install_dir = vim.fn.stdpath "data" .. "/site",
   },
-  
-  -- You can add more parsers based on languages you use:
-  -- "javascript", "typescript", "python", "rust", "go", "c", "cpp",
-  -- "html", "css", "json", "yaml", "markdown", "bash", etc.
-  -- Or install them on-demand with :TSInstall <language>
-
-  -- HIGHLIGHTING
-  -- The main feature - syntax highlighting using tree-sitter parsing
-  
-  highlight = {
-    -- Enable treesitter-based syntax highlighting
-    -- This replaces Vim's traditional regex-based highlighting
-    -- Much more accurate: understands code structure, not just patterns
-    enable = true,
-    
-    -- Use languagetree for embedded languages
-    -- Example: correctly highlights JavaScript inside HTML <script> tags
-    -- Each embedded language gets its own parser
-    use_languagetree = true,
+  ensure_installed = parsers,
+  highlight_filetypes = filetypes,
+  indent_filetypes = filetypes,
+  parsers_by_filetype = {
+    javascriptreact = "javascript",
+    typescriptreact = "tsx",
   },
-
-  -- INDENTATION
-  -- Treesitter can calculate correct indentation based on code structure
-  
-  indent = { 
-    -- Enable treesitter-based automatic indentation
-    -- When you press Enter, treesitter figures out the correct indent level
-    -- Based on actual code structure (inside function? inside if block? etc.)
-    enable = true 
-  },
-  
-  -- OTHER MODULES (using defaults or disabled)
-
-  -- Treesitter has many other modules that can be enabled:
-  
-  -- incremental_selection = { enable = true }
-  --   Expand selection based on syntax: select word -> statement -> function -> file
-  
-  -- textobjects = { ... }
-  --   Define text objects like "function", "class", "parameter" for motions
-  --   Example: daf = delete a function, vif = select inside function
-  
-  -- folding = { enable = true }
-  --   Code folding based on syntax structure (fold functions, classes, etc.)
-  
-  -- refactor = { ... }
-  --   Highlighting for same variables, smart rename, etc.
-  
-  -- playground = { ... }
-  --   Debug tool to explore the syntax tree
 }

--- a/nvim/lua/plugins/init.lua
+++ b/nvim/lua/plugins/init.lua
@@ -268,20 +268,43 @@ return {
   -- Much better than Vim's traditional regex-based syntax highlighting
   {
     "nvim-treesitter/nvim-treesitter",
-    -- Use the master branch (some plugins require specific branches)
-    branch = "master",
-    -- Load when opening or creating files
-    event = { "BufReadPost", "BufNewFile" },
-    -- Also load when these commands are used
-    cmd = { "TSInstall", "TSBufEnable", "TSBufDisable", "TSModuleInfo" },
+    -- The master branch is frozen; Neovim 0.12 requires the new main branch API.
+    branch = "main",
+    -- Upstream does not support lazy-loading on the main branch.
+    lazy = false,
     -- Run :TSUpdate after install to compile the parsers
     build = ":TSUpdate",
     opts = function()
       return require "configs.treesitter"
     end,
     config = function(_, opts)
-      -- Setup treesitter with our configuration
-      require("nvim-treesitter.configs").setup(opts)
+      local treesitter = require "nvim-treesitter"
+
+      treesitter.setup(opts.setup)
+
+      for filetype, parser in pairs(opts.parsers_by_filetype or {}) do
+        vim.treesitter.language.register(parser, filetype)
+      end
+
+      if opts.ensure_installed and #opts.ensure_installed > 0 then
+        treesitter.install(opts.ensure_installed)
+      end
+
+      local indent_filetypes = {}
+      for _, filetype in ipairs(opts.indent_filetypes or {}) do
+        indent_filetypes[filetype] = true
+      end
+
+      vim.api.nvim_create_autocmd("FileType", {
+        desc = "Start treesitter",
+        group = vim.api.nvim_create_augroup("UserTreesitter", { clear = true }),
+        pattern = opts.highlight_filetypes,
+        callback = function(args)
+          if pcall(vim.treesitter.start, args.buf) and indent_filetypes[vim.bo[args.buf].filetype] then
+            vim.bo[args.buf].indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"
+          end
+        end,
+      })
     end,
   },
 


### PR DESCRIPTION
## Summary
- move nvim-treesitter lock/plugin config to the main branch API
- update parser install/startup configuration
- keep the nvim-tree filter change separate in PR #4

## Validation
- git diff --cached --check
- nvim --headless '+lua require("lazy").load({ plugins = { "nvim-treesitter" } })' '+qa'