### PR TITLE
feat(keymaps): add Cmd navigation mappings

### DIFF
--- a/ghostty
+++ b/ghostty
@@ -84,23 +84,27 @@ macos-window-shadow = false
 
 
 # CUSTOM KEYBINDINGS
-# All cmd+key combos handled by Karabiner → ctrl+shift+alt → CSI u sequences
+# Cmd shortcuts that need to reach terminal apps are routed through Karabiner
+# as ctrl+alt chords, then converted here to CSI u sequences.
 keybind = cmd+n=text:\x1b[32~
 
-# Send escape sequences for cmd+j/k (for Telescope navigation)
+# Direct cmd+j/k fallback if Karabiner is not running
 keybind = cmd+j=text:\x1b[106;9u
 keybind = cmd+k=text:\x1b[107;9u
 
-# Buffer navigation (Karabiner remaps cmd+h/l/q → ctrl+alt+h/l/q)
+# Telescope navigation (Karabiner remaps cmd+j/k → ctrl+alt+j/k)
+keybind = ctrl+alt+j=text:\x1b[106;7u
+keybind = ctrl+alt+k=text:\x1b[107;7u
+
+# Buffer navigation (Karabiner remaps cmd+h/l/q -> ctrl+alt+h/l/q)
 keybind = ctrl+alt+h=text:\x1b[104;7u
 keybind = ctrl+alt+l=text:\x1b[108;7u
 keybind = ctrl+alt+q=text:\x1b[113;7u
 
-# Splits (Karabiner remaps cmd+\/- → ctrl+alt+\/-)
+# Splits (Karabiner remaps cmd+\/- -> ctrl+alt+\/-)
 keybind = ctrl+alt+backslash=text:\x1b[92;7u
 keybind = ctrl+alt+-=text:\x1b[45;7u
 
 
 # Window sizing
 maximize = true
-

--- a/karabiner/karabiner.json
+++ b/karabiner/karabiner.json
@@ -7,7 +7,7 @@
             "complex_modifications": {
                 "rules": [
                     {
-                        "description": "cmd+h to ctrl+shift+alt+h in Ghostty",
+                        "description": "cmd+h to ctrl+alt+h in Ghostty",
                         "manipulators": [
                             {
                                 "type": "basic",
@@ -18,7 +18,29 @@
                         ]
                     },
                     {
-                        "description": "cmd+l to ctrl+shift+alt+l in Ghostty",
+                        "description": "cmd+j to ctrl+alt+j in Ghostty",
+                        "manipulators": [
+                            {
+                                "type": "basic",
+                                "from": { "key_code": "j", "modifiers": { "mandatory": ["command"] } },
+                                "to": [{ "key_code": "j", "modifiers": ["control", "option"] }],
+                                "conditions": [{ "type": "frontmost_application_if", "bundle_identifiers": ["com.mitchellh.ghostty"] }]
+                            }
+                        ]
+                    },
+                    {
+                        "description": "cmd+k to ctrl+alt+k in Ghostty",
+                        "manipulators": [
+                            {
+                                "type": "basic",
+                                "from": { "key_code": "k", "modifiers": { "mandatory": ["command"] } },
+                                "to": [{ "key_code": "k", "modifiers": ["control", "option"] }],
+                                "conditions": [{ "type": "frontmost_application_if", "bundle_identifiers": ["com.mitchellh.ghostty"] }]
+                            }
+                        ]
+                    },
+                    {
+                        "description": "cmd+l to ctrl+alt+l in Ghostty",
                         "manipulators": [
                             {
                                 "type": "basic",
@@ -29,7 +51,7 @@
                         ]
                     },
                     {
-                        "description": "cmd+q to ctrl+shift+alt+q in Ghostty",
+                        "description": "cmd+q to ctrl+alt+q in Ghostty",
                         "manipulators": [
                             {
                                 "type": "basic",
@@ -40,7 +62,7 @@
                         ]
                     },
                     {
-                        "description": "cmd+backslash to ctrl+shift+alt+backslash in Ghostty",
+                        "description": "cmd+backslash to ctrl+alt+backslash in Ghostty",
                         "manipulators": [
                             {
                                 "type": "basic",
@@ -51,7 +73,7 @@
                         ]
                     },
                     {
-                        "description": "cmd+minus to ctrl+shift+alt+minus in Ghostty",
+                        "description": "cmd+minus to ctrl+alt+minus in Ghostty",
                         "manipulators": [
                             {
                                 "type": "basic",

--- a/nvim/lua/configs/cmp.lua
+++ b/nvim/lua/configs/cmp.lua
@@ -35,12 +35,16 @@ local options = {
   -- These control how you interact with the completion menu
   
   mapping = {
-    -- Ctrl+p / Alt+k: Select previous item in the completion menu
+    -- Ctrl+p / Cmd+k / Alt+k: Select previous item in the completion menu
     ["<C-p>"] = cmp.mapping.select_prev_item(),
+    ["<D-k>"] = cmp.mapping.select_prev_item(),
+    ["<M-C-k>"] = cmp.mapping.select_prev_item(),
     ["<M-k>"] = cmp.mapping.select_prev_item(),
 
-    -- Ctrl+n / Alt+j: Select next item in the completion menu
+    -- Ctrl+n / Cmd+j / Alt+j: Select next item in the completion menu
     ["<C-n>"] = cmp.mapping.select_next_item(),
+    ["<D-j>"] = cmp.mapping.select_next_item(),
+    ["<M-C-j>"] = cmp.mapping.select_next_item(),
     ["<M-j>"] = cmp.mapping.select_next_item(),
     
     -- Ctrl+d: Scroll documentation window DOWN by 4 lines

--- a/nvim/lua/configs/telescope.lua
+++ b/nvim/lua/configs/telescope.lua
@@ -63,6 +63,10 @@ return {
 
       -- Insert mode mappings (default mode when telescope opens)
       i = {
+        ["<D-j>"] = require("telescope.actions").move_selection_next,
+        ["<D-k>"] = require("telescope.actions").move_selection_previous,
+        ["<M-C-j>"] = require("telescope.actions").move_selection_next,
+        ["<M-C-k>"] = require("telescope.actions").move_selection_previous,
         ["<M-j>"] = require("telescope.actions").move_selection_next,
         ["<M-k>"] = require("telescope.actions").move_selection_previous,
       },

--- a/nvim/lua/mappings.lua
+++ b/nvim/lua/mappings.lua
@@ -36,10 +36,10 @@ map("i", "<C-k>", "<Up>", { desc = "move up" })
 -- WINDOW SPLITS
 -- Create new split windows with intuitive keybindings
 
--- Cmd+\: Create vertical split (Karabiner → ctrl+shift+alt+\)
+-- Cmd+\: Create vertical split (Karabiner -> ctrl+alt+\)
 map("n", "<M-C-\\>", "<cmd>vsplit<CR>", { desc = "vertical split" })
 
--- Cmd+-: Create horizontal split (Karabiner → ctrl+shift+alt+-)
+-- Cmd+-: Create horizontal split (Karabiner -> ctrl+alt+-)
 map("n", "<M-C-_>", "<cmd>split<CR>", { desc = "horizontal split" })
 
 -- GENERAL UTILITIES
@@ -192,13 +192,13 @@ if require("nvconfig").ui.tabufline.enabled then
   -- :enew = edit new (creates empty unnamed buffer)
   map("n", "<leader>b", "<cmd>enew<CR>", { desc = "buffer new" })
 
-  -- Cmd+H: Go to previous buffer (Karabiner → ctrl+shift+alt+h → <M-C-H>)
+  -- Cmd+H: Go to previous buffer (Karabiner -> ctrl+alt+h -> <M-C-H>)
   map("n", "<M-C-H>", function() require("nvchad.tabufline").prev() end, { desc = "buffer goto prev" })
 
-  -- Cmd+L: Go to next buffer (Karabiner → ctrl+shift+alt+l → <M-C-L>)
+  -- Cmd+L: Go to next buffer (Karabiner -> ctrl+alt+l -> <M-C-L>)
   map("n", "<M-C-L>", function() require("nvchad.tabufline").next() end, { desc = "buffer goto next" })
 
-  -- Cmd+Q: Close the current buffer (Karabiner → ctrl+shift+alt+q → <M-C-Q>)
+  -- Cmd+Q: Close the current buffer (Karabiner -> ctrl+alt+q -> <M-C-Q>)
   map("n", "<M-C-Q>", function()
     local ok, err = pcall(require("nvchad.tabufline").close_buffer)
     if not ok and not err:match("E517") then
@@ -298,4 +298,3 @@ map("n", "<leader>rx", ":DistantSpawn ", { desc = "distant spawn remote command"
 -- Leader+rp: Quick connect to Raspberry Pi
 -- Shortcut for connecting to Pi at known IP
 map("n", "<leader>rp", "<cmd>DistantLaunch ssh://ukibbb@192.168.101.7<CR>", { desc = "distant connect to Raspberry Pi" })
-


### PR DESCRIPTION
## Summary
- add Ghostty/Karabiner routing for Cmd-style navigation
- add matching Telescope and nvim-cmp movement mappings
- update related mapping comments

## Validation
- git diff --cached --check
- python -m json.tool karabiner/karabiner.json >/dev/null
- nvim --headless '+lua require("lazy").load({ plugins = { "telescope.nvim", "nvim-cmp" } })' '+qa'